### PR TITLE
Fixed a few minor bugs/typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Endpoint: `POST /pacer/credentials`
 Example:
 
 ```shell
-  ./pacer/save-credentials.sh test secret | jq
+  $ ./pacer/save-credentials.sh test secret | jq
   {
     "app_id": "25ed3872",
     "pacer_user": "test"
@@ -1745,7 +1745,7 @@ Usage: `./pacer/search-filings.sh <case_uuid>`
 
 Example:
 ```shell
- $ ./pacer/search-filings.sh nysbke_247775
+ $ ./pacer/search-filings.sh nysbke_247775 | jq
 {
   "facets" => {
     "chapter" => {

--- a/config.sh
+++ b/config.sh
@@ -9,11 +9,11 @@ if [ -z "$COURTAPI_SECRET" ]; then
 fi
 
 if [ -z "$COURTAPI_HOST" ]; then
-  COURTAPI_HOST="courtapi.courtio.dev.azk.io"
+  COURTAPI_HOST="train.v1.courtapi.com"
 fi
 
 if [ -z "$COURTAPI_SCHEME" ]; then
-  COURTAPI_SCHEME="http"
+  COURTAPI_SCHEME="https"
 fi
 
 if [ -z "$COURTAPI_BASE_URL" ]; then

--- a/court/search-cases.sh
+++ b/court/search-cases.sh
@@ -10,5 +10,5 @@ fi
 court="$1"
 case="$2"
 
-# Lots of possibilities on what to search for.  This just shows cases filed a specific month
+# Lots of possibilities on what to search for. This looks up a case based on the case number.
 curl -s -XPOST $COURTAPI_BASE_URL/courts/pacer/$court/cases/search -d case_no="$case"


### PR DESCRIPTION
Found and fixed a few minor bugs/typos:

- In `search-cases.sh`, the comment seems to be wrong.
- In `config.sh`, we might want to update the default host and scheme (`train.v1.courtapi.com` and `https`)?
- In `README.md`, the first example (“Save PACER Credentials”) is missing the initial `$` bash prompt.
- Also in `README.md`, the last example (“Advanced Filings Search”) is missing `| jq` in the shell command.
